### PR TITLE
place div.lane .max to bottom-left corner

### DIFF
--- a/style.css
+++ b/style.css
@@ -231,12 +231,15 @@ div.destination {
   top: -15px; }
 
 div.destination.double {
+  z-index: 1;
   width: 230px; }
 
 div.destination.triple {
+  z-index: 1;
   width: 350px; }
 
 div.destination.quadruple {
+  z-index: 1;
   width: 470px; }
 
 .extrasize div.destination {

--- a/style.css
+++ b/style.css
@@ -160,7 +160,9 @@ div.condition.hgv {
   height: 35px; }
 
 div.lane .max {
-  float: none; }
+  position: absolute;
+  bottom: 10px;
+  left: 10px; }
 
 .extrasize div.lane, .extrasize div.nolane {
   width: 177.6px;
@@ -170,6 +172,7 @@ div.lane .max {
   left: 984.4px; }
 
 div.lane {
+  position: relative;
   background: #cdc;
   height: 135px;
   border-left: 3px dashed white;

--- a/style.scss
+++ b/style.scss
@@ -287,12 +287,15 @@ div.destination {
   }    
 
 div.destination.double {
+  z-index: 1;
   width:(2*$laneWidth - $laneSub - 4px);
   }  
 div.destination.triple {
+  z-index: 1;
   width:(3*$laneWidth - $laneSub - 4px);
   }
 div.destination.quadruple {
+  z-index: 1;
   width:(4*$laneWidth - $laneSub - 4px);
   }
 

--- a/style.scss
+++ b/style.scss
@@ -198,7 +198,9 @@ div.condition.hgv {
   }  
   
 div.lane .max {
-  float:none;
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
   }  
 
 .extrasize {
@@ -214,6 +216,7 @@ div.lane .max {
 
   
 div.lane {
+  position: relative;
   background:#cdc;
   height:$laneHeight;
   border-left:3px dashed white;


### PR DESCRIPTION
Bei "pro Lane .max" und gleichzeitigem "double" wird das zweite .max hinter das double gesetzt. 
![image](https://cloud.githubusercontent.com/assets/8296940/6236191/88490fee-b6e8-11e4-853b-08f08655e91f.png)

Folgender Fix, getestet in Chromium, platziert div.lane .max absolut in die untere linke Ecke. Ich habe auch nichts entdeckt, ob diese Ecke schon zu einem anderen Zweck "reserviert" ist. Vielleicht passt das in dein Konzept. 
![image](https://cloud.githubusercontent.com/assets/8296940/6236223/d6250204-b6e8-11e4-9de8-40af2efc4a04.png)
